### PR TITLE
Fix application logger

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
     <name>OCC Web</name>
     <summary>OCC Commands in a web terminal</summary>
     <description><![CDATA[Run OCC Commands in a web terminal]]></description>
-    <version>0.0.7</version>
+    <version>0.1.0</version>
     <licence>agpl</licence>
     <author mail="adphi.apps@gmail.com" >Adphi</author>
     <namespace>OCCWeb</namespace>
@@ -15,7 +15,7 @@
     <repository>https://git.adphi.net/adphi/occweb</repository>
     <screenshot>https://git.adphi.net/adphi/occweb/raw/master/appinfo/screenshot.png</screenshot>
     <dependencies>
-        <nextcloud min-version="13" max-version="18"/>
+        <nextcloud min-version="19" max-version="23"/>
     </dependencies>
     <navigations>
         <navigation role="admin">

--- a/lib/Controller/OccController.php
+++ b/lib/Controller/OccController.php
@@ -13,6 +13,7 @@ use OCP\AppFramework\Controller;
 use OCP\ILogger;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\OutputInterface;
+use Psr\Log\LoggerInterface;
 
 class OccController extends Controller
 {
@@ -32,7 +33,7 @@ class OccController extends Controller
       OC::$server->getConfig(),
       OC::$server->getEventDispatcher(),
       new FakeRequest(),
-      OC::$server->getLogger(),
+      OC::$server->get(LoggerInterface::class),
       OC::$server->query(MemoryInfo::class)
     );
     $this->application->setAutoExit(false);


### PR DESCRIPTION
Hi there,

I know you have deprecated this app, but running two instances on managed web hosts without console access this is my only means of accessing occ 🙈 

This app stopped working in NC 22 due changes in the constructor of `OC\Console\Application`. This PR gets the app back to a working state.

Would you be so kind to update your app in the store?