### PR TITLE
NC26+ Compatibility

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,7 +5,7 @@
     <name>OCC Web</name>
     <summary>OCC Commands in a web terminal</summary>
     <description><![CDATA[Run OCC Commands in a web terminal]]></description>
-    <version>0.1.0</version>
+    <version>0.1.1</version>
     <licence>agpl</licence>
     <author mail="adphi.apps@gmail.com" >Adphi</author>
     <namespace>OCCWeb</namespace>
@@ -15,7 +15,7 @@
     <repository>https://github.com/adphi/occweb</repository>
     <screenshot>https://github.com/adphi/occweb/raw/master/appinfo/screenshot.png</screenshot>
     <dependencies>
-        <nextcloud min-version="19" max-version="23"/>
+        <nextcloud min-version="19" max-version="27"/>
     </dependencies>
     <navigations>
         <navigation role="admin">

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -11,6 +11,6 @@ return [
     'routes' => [
 	   ['name' => 'occ#index', 'url' => '/', 'verb' => 'GET'],
 	   ['name' => 'occ#cmd', 'url' => '/cmd', 'verb' => 'POST'],
-     ['name' => 'occ#list', 'url' => '/cmd', 'verb' => 'GET'],
+       ['name' => 'occ#list', 'url' => '/cmd', 'verb' => 'GET'],
     ]
 ];

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -11,6 +11,6 @@ return [
     'routes' => [
 	   ['name' => 'occ#index', 'url' => '/', 'verb' => 'GET'],
 	   ['name' => 'occ#cmd', 'url' => '/cmd', 'verb' => 'POST'],
-       ['name' => 'occ#list', 'url' => '/cmd', 'verb' => 'GET'],
+	   ['name' => 'occ#list', 'url' => '/cmd', 'verb' => 'GET'],
     ]
 ];

--- a/lib/Controller/OccController.php
+++ b/lib/Controller/OccController.php
@@ -21,6 +21,7 @@ class OccController extends Controller
   private $userId;
 
   private $application;
+  private $symphonyApplication;
   private $output;
 
   public function __construct(ILogger $logger, $AppName, IRequest $request, $userId)
@@ -38,7 +39,10 @@ class OccController extends Controller
     );
     $this->application->setAutoExit(false);
     $this->output = new OccOutput(OutputInterface::VERBOSITY_NORMAL, true);
-    $this->application->loadCommands(new StringInput(""), $this->output);
+    $this->application->loadCommands(new StringInput(""), $this->output);    
+    $reflectionProperty = new \ReflectionProperty(Application::class, 'application');
+    $reflectionProperty->setAccessible(true);
+    $this->symphonyApplication = $reflectionProperty->getValue($this->application);
   }
 
   /**
@@ -78,11 +82,11 @@ class OccController extends Controller
   }
 
   public function list() {
-    // $defs = $this->application->application->all();
+    $defs = $this->symphonyApplication->all();
     $cmds = array();
-    // foreach ($defs as $d) {
-    //   array_push($cmds, $d->getName());
-    // }
+    foreach ($defs as $d) {
+      array_push($cmds, $d->getName());
+    }
     return new DataResponse($cmds);
   }
 }

--- a/lib/Controller/OccController.php
+++ b/lib/Controller/OccController.php
@@ -78,11 +78,11 @@ class OccController extends Controller
   }
 
   public function list() {
-    $defs = $this->application->application->all();
+    // $defs = $this->application->application->all();
     $cmds = array();
-    foreach ($defs as $d) {
-      array_push($cmds, $d->getName());
-    }
+    // foreach ($defs as $d) {
+    //   array_push($cmds, $d->getName());
+    // }
     return new DataResponse($cmds);
   }
 }


### PR DESCRIPTION
Fixes #5, #6

Uses reflection to get the symphony application from out of `OC\Console\Application` to keep tab completion working

Tested on NC27.0.2

I'm not going to let OCCWeb die so easy.... 😉 